### PR TITLE
Update GNU Global version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install the distributed files into your Vim script directory which is usually
 
 ## Prerequisite
 
-GNU GLOBAL (5.7 or later) must be installed your system and the executable binary `global` on your PATH.
+GNU GLOBAL (6.0 or later) must be installed your system and the executable binary `global` on your PATH.
 
 ## Usage
 


### PR DESCRIPTION
According to the release notes (https://lists.gnu.org/archive/html/info-gnu/2011-09/msg00008.html) the output format 'ctags-mod' was introduced in version 6.0 of GNU Global.
