### PR TITLE
Add through_all_tags option to go through GTAGSLIBPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Following items are configured for each project:
 - `treelize (0 or 1)`: show Unite's items in tree format or not
 - `absolute_path (0 or 1)`: add `-a` option to global command or not
 - `gtags_libpath (list of string)`: join with ':' and use it as `GTAGSLIBPATH`
+- `through_all_tags (0 or 1)`: add `--through` option to global command or not
 
 You can set default configuration with specifying `_` as project name.
 
@@ -154,6 +155,12 @@ When configure gtags\_libpath with following
 `unite-gtags` executes `global` with temporary environment variable `GTAGSLIBPATH` like below
 
     GTAGSLIBPATH=$GTAGSLIBPATH:/usr/include/:/home/foo/include/ global ...
+
+#### through\_all\_tags
+
+By default, a search is ended without go through all the tag files listed in GTAGSLIBPATH when tags are found in a project's tag file. This behavior may be unintended if there are definitions with the same name as the one defined in a project.
+
+When `through_all_tags = 1`, `unite-gtags` adds `--through` option to `global` command and it makes a search go through all the tag files listed in GTAGSLIBPATH. This option is ignored when either `-s`, `-r` or `-l` option is specified.
 
 ### Syntax Highlight
 

--- a/autoload/unite/libs/gtags.vim
+++ b/autoload/unite/libs/gtags.vim
@@ -53,6 +53,7 @@ let s:default_project_config_value = {
       \ 'treelize': 0,
       \ 'absolute_path': 0,
       \ 'gtags_libpath': [],
+      \ 'through_all_tags': 0,
       \ }
 
 function! unite#libs#gtags#get_global_config(key)
@@ -75,7 +76,8 @@ endfunction
 " execute global command and return result
 function! unite#libs#gtags#exec_global(short_option, long_option, pattern)
   let l:long_option = a:long_option .
-        \ (unite#libs#gtags#get_global_config("enable_nearness") ? " --nearness=\"" . fnamemodify(expand('%:p'), ':h') . "\"" : '')
+        \ (unite#libs#gtags#get_global_config("enable_nearness") ? " --nearness=\"" . fnamemodify(expand('%:p'), ':h') . "\"" : '') .
+        \ (unite#libs#gtags#get_project_config("through_all_tags") ? " --through" : '')
   let l:short_option = a:short_option . (unite#libs#gtags#get_project_config("absolute_path") ? "a" : '')
   " build command
   let l:cmd = printf("%s %s -q%s %s",


### PR DESCRIPTION
This PR  is adding "--through" option support.

By default, a search is ended without go through all the tag files listed in GTAGSLIBPATH when tags are found in a project's tag file. This behavior may be unintended if there are definitions with the same name as the one defined in a project.

When `through_all_tags = 1`, `unite-gtags` adds `--through` option to `global` command and it makes a search go through all the tag files listed in GTAGSLIBPATH.