### PR TITLE
add gtags/path source

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This source provides following sub commands for `Unite`
 - `Unite gtags/grep`
 - `Unite gtags/completion`
 - `Unite gtags/file`
+- `Unite gtags/path`
 
 ### Unite gtags/context
 
@@ -76,6 +77,14 @@ It executes `global -f` and show results.
 
 You can specify `<pattern>` as an argument `:Unite gtags/file:<pathname>`.
 When exeucte this command with no arguments `:Unite gtags/file`, unite-gtags uses `buffer_name("%")` as filepath.
+
+### Unite gtags/path
+
+`Unite gtags/path` lists all paths in GTAGS.
+It executes `global -P` and show results.
+
+You can specify `<pattern>` as an argument `:Unite gtags/path:<pattern>`.
+When exeucte Unite with no arguments `:Unite gtags/path`, all paths is shown.
 
 ## Configuration
 

--- a/autoload/unite/libs/gtags.vim
+++ b/autoload/unite/libs/gtags.vim
@@ -45,6 +45,7 @@ let s:default_config = {
       \ "ref_option" : "rs -e",
       \ "def_option" : "d -e",
       \ "result_option" : "ctags-mod",
+      \ "path_option" : "P -e",
       \ "global_cmd" : "global",
       \ "enable_nearness" : 0,
       \ }
@@ -149,7 +150,7 @@ function! unite#libs#gtags#result2unite(source, result, context)
         \ 's:format["'. unite#libs#gtags#get_global_config("result_option") . '"].func(v:val)')
   let l:candidates = filter(l:candidates, '!empty(v:val)')
   let l:candidates = map(l:candidates, 'extend(v:val, {"source" : a:source})')
-  let a:context.is_treelized = !(a:context.immediately && len(l:candidates) == 1) && 
+  let a:context.is_treelized = !(a:context.immediately && len(l:candidates) == 1) &&
         \ unite#libs#gtags#get_project_config('treelize')
   if a:context.is_treelized
     return unite#libs#gtags#treelize(l:candidates)

--- a/autoload/unite/sources/gtags.vim
+++ b/autoload/unite/sources/gtags.vim
@@ -53,7 +53,7 @@ function! s:def.option(args, context)
   return {
         \'short': unite#libs#gtags#get_global_config("def_option"),
         \'long': '',
-        \'pattern' : l:pattern 
+        \'pattern' : l:pattern
         \}
 endfunction
 " }}}
@@ -166,8 +166,34 @@ function! s:file.option(args, context)
   return {
         \'short': 'f',
         \'long': '',
-        \'pattern' : l:pattern 
+        \'pattern' : l:pattern
         \}
+endfunction
+" }}}
+
+" source gtags/path {{{
+let s:path = {
+      \ 'name' : 'path',
+      \ 'description' : 'global with -P option',
+      \ 'enable_tree_matcher' : 1,
+      \ 'hooks'  : {
+         \'on_syntax' : function("unite#libs#gtags#on_syntax"),
+         \'on_init'   : function("unite#libs#gtags#on_init_common"),
+         \ },
+      \ 'syntax' : "uniteSource__Gtags",
+      \ 'result' : function('unite#libs#gtags#result_as_filepath'),
+      \}
+function! s:path.option(args, context)
+  if empty(a:args)
+    let l:pattern = ''
+  else
+    let l:pattern = a:args[0]
+  endif
+  return {
+        \ 'short': unite#libs#gtags#get_global_config("path_option"),
+        \ 'long': '',
+        \ 'pattern' : l:pattern ,
+        \ }
 endfunction
 " }}}
 
@@ -178,6 +204,7 @@ let s:gtags_commands  = [
       \ s:completion,
       \ s:grep,
       \ s:file,
+      \ s:path,
       \]
 
 function! unite#sources#gtags#define()


### PR DESCRIPTION
`Unite gtags/path` lists all paths in GTAGS.
It executes `global -P` and show results.

You can specify `<pattern>` as an argument `:Unite gtags/path:<pattern>`.
When exeucte Unite with no arguments `:Unite gtags/path`, all paths is shown.
