### PR TITLE
fix #12 Error parsing ctags-x result when source line contains '.'

### DIFF
--- a/autoload/unite/libs/gtags.vim
+++ b/autoload/unite/libs/gtags.vim
@@ -9,7 +9,7 @@ let s:format = {
       \ }
 
 function! s:format["ctags-x"].func(line)
-  let l:items = matchlist(a:line, '\s\+\(\d\+\)\s\+\(.*\.\S\+\)\s\(.*\)$')
+  let l:items = matchlist(a:line, '\s\+\(\d\+\)\s\+\(.\{-}\.\S\+\)\s\(.*\)$')
   if empty(l:items)
     call unite#print_error('[unite-gtags] unexpected result for ctags-x: ' . a:line)
     return {}


### PR DESCRIPTION
fix #12 