### PR TITLE
[Compat] remove ver 5.7 desc from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ Install the distributed files into your Vim script directory which is usually
 
 GNU GLOBAL (5.7 or later) must be installed your system and the executable binary `global` on your PATH.
 
-By default, `unite-gtags` assumes GNU GLOBAL 6.X.
-If you use GNU GLOBAL 5.X, see `GNU GLOBAL Compatibility` section.
-
 ## Usage
 
 This source provides following sub commands for `Unite`
@@ -180,16 +177,4 @@ When `through_all_tags = 1`, `unite-gtags` adds `--through` option to `global` c
 * `uniteSource__Gtags_Path`
 
     Highlight for filepath (default linked to `File`).
-
-### GNU GLOBAL Compatibility
-
-#### GNU GLOBAL 5.7
-
-If you use GNU GLOBAL 5.X please set following global variables in your vimrc.
-
-- `g:unite_source_gtags_ref_option`: `"r"`
-- `g:unite_source_gtags_def_option`: `""` (empty string)
-- `g:unite_source_gtags_result_option`: `"ctags-x"`
-
-(test only GNU GLOBAL 5.7.1 in Ubuntu 14.04)
 


### PR DESCRIPTION
I confirmed GNU GLOBAL 6.X is provided as deb package in ubuntu.
Major Linux distributions provide newer than 6.X.
Thus, I decided to remove compatibility descriptions from README
(option variables for each command remain.)